### PR TITLE
Bugfix on socket.py

### DIFF
--- a/irradpy/downloader/socket.py
+++ b/irradpy/downloader/socket.py
@@ -120,7 +120,7 @@ def run(
     # Call the main function
     socket = SocketManager()
     socket.daily_download_and_convert(
-        collection_names, merra2_var_dicts=None,
+        collection_names, merra2_var_dicts=merra2_var_dicts,
         initial_year=initial_year, initial_month=initial_month, initial_day=initial_day,
         final_year=final_year, final_month=final_month, final_day=final_day,
         output_dir=output_dir,

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ if __name__ == "__main__":
     assert sys.version_info >= (3, 6), "Minimum Python >= 3.6 is required!"
     setup(
         name = "irradpy",
-        version = "1.5.1",
+        version = "1.5.0",
         keywords = ("MERRA2", "Clear Sky Model", "Solar Energy"),
         description = "Download tool for MERRA2 dataset for Clear Sky Model.",
         long_description = "This is a automated tool for MERRA2 data collection and filtering, for the analysis of Clear Sky Model.",

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ if __name__ == "__main__":
     assert sys.version_info >= (3, 6), "Minimum Python >= 3.6 is required!"
     setup(
         name = "irradpy",
-        version = "1.5.0",
+        version = "1.5.1",
         keywords = ("MERRA2", "Clear Sky Model", "Solar Energy"),
         description = "Download tool for MERRA2 dataset for Clear Sky Model.",
         long_description = "This is a automated tool for MERRA2 data collection and filtering, for the analysis of Clear Sky Model.",


### PR DESCRIPTION
The function `run` was ignoring the variable `merra2_var_dicts`, instead of using it in the call to `daily_download_and_convert`. 
So the user ended up downloading the default set of variables, instead of the ones requested. 


